### PR TITLE
Replaces StateSelect.always with StateSelect.prefer. 

### DIFF
--- a/ThermalSeparation/BalanceEquations/Base/Equilibrium/BaseTwoPhaseVarState.mo
+++ b/ThermalSeparation/BalanceEquations/Base/Equilibrium/BaseTwoPhaseVarState.mo
@@ -13,7 +13,7 @@ extends
   Modelica.SIunits.AmountOfSubstance n_mol[n,nS];
 
 protected
-  Real eps_liq_state[n](each stateSelect=StateSelect.always)=eps_liq;
+  Real eps_liq_state[n](each stateSelect=StateSelect.prefer)=eps_liq;
 
 equation
 stat=false;

--- a/ThermalSeparation/BalanceEquations/Base/NonEquilibrium/BaseTwoPhaseFixedState.mo
+++ b/ThermalSeparation/BalanceEquations/Base/NonEquilibrium/BaseTwoPhaseFixedState.mo
@@ -5,12 +5,12 @@ extends
     ThermalSeparation.BalanceEquations.Base.NonEquilibrium.BaseBalanceEquationsNonEq;
 
 /*** changes to reduce index: fixed state selection ***/
-  input SI.MolarInternalEnergy u_v[n](stateSelect=StateSelect.always);
-  input SI.MolarInternalEnergy u_l[n](stateSelect=StateSelect.always);
-  Modelica.SIunits.AmountOfSubstance n_mol_L[n](stateSelect=StateSelect.always);
-  Modelica.SIunits.AmountOfSubstance n_mol_V[n](stateSelect=StateSelect.always);
-  Modelica.SIunits.AmountOfSubstance n_mol_L_i[n,nSL](stateSelect=StateSelect.always);
-  Modelica.SIunits.AmountOfSubstance n_mol_V_i[n,nSV](stateSelect=StateSelect.always);
+  input SI.MolarInternalEnergy u_v[n](stateSelect=StateSelect.prefer);
+  input SI.MolarInternalEnergy u_l[n](stateSelect=StateSelect.prefer);
+  Modelica.SIunits.AmountOfSubstance n_mol_L[n](stateSelect=StateSelect.prefer);
+  Modelica.SIunits.AmountOfSubstance n_mol_V[n](stateSelect=StateSelect.prefer);
+  Modelica.SIunits.AmountOfSubstance n_mol_L_i[n,nSL](stateSelect=StateSelect.prefer);
+  Modelica.SIunits.AmountOfSubstance n_mol_V_i[n,nSV](stateSelect=StateSelect.prefer);
   Modelica.SIunits.AmountOfSubstance n_mol[n,nS];
 
 equation

--- a/ThermalSeparation/BalanceEquations/Base/NonEquilibrium/BaseTwoPhaseSteadyState.mo
+++ b/ThermalSeparation/BalanceEquations/Base/NonEquilibrium/BaseTwoPhaseSteadyState.mo
@@ -8,7 +8,7 @@ extends
   input SI.MolarInternalEnergy u_l[n](each stateSelect=StateSelect.default);
 
 protected
-  Real eps_liq_state[n]=eps_liq;//(each stateSelect=StateSelect.always)=eps_liq;
+  Real eps_liq_state[n]=eps_liq;//(each stateSelect=StateSelect.prefer)=eps_liq;
 
 equation
 stat=false;

--- a/ThermalSeparation/BalanceEquations/Base/NonEquilibrium/BaseTwoPhaseVarState.mo
+++ b/ThermalSeparation/BalanceEquations/Base/NonEquilibrium/BaseTwoPhaseVarState.mo
@@ -8,7 +8,7 @@ extends
   input SI.MolarInternalEnergy u_l[n](each stateSelect=StateSelect.default);
 
 protected
-  Real eps_liq_state[n]=eps_liq;//(each stateSelect=StateSelect.always)=eps_liq;
+  Real eps_liq_state[n]=eps_liq;//(each stateSelect=StateSelect.prefer)=eps_liq;
 
 equation
 stat=false;

--- a/ThermalSeparation/BalanceEquations/Base/NonEquilibrium/BaseTwoPhaseVarStateFixEps.mo
+++ b/ThermalSeparation/BalanceEquations/Base/NonEquilibrium/BaseTwoPhaseVarStateFixEps.mo
@@ -10,7 +10,7 @@ extends
   parameter Real eps_liq_user=0.28;
 
 protected
-  Real eps_liq_state[n]=eps_liq;//( stateSelect=StateSelect.always)=eps_liq;
+  Real eps_liq_state[n]=eps_liq;//( stateSelect=StateSelect.prefer)=eps_liq;
 
 equation
 stat=false;

--- a/ThermalSeparation/BalanceEquations/BaseNonEq/NonEquilibrium/BaseTwoPhaseFixedState.mo
+++ b/ThermalSeparation/BalanceEquations/BaseNonEq/NonEquilibrium/BaseTwoPhaseFixedState.mo
@@ -4,12 +4,12 @@ model BaseTwoPhaseFixedState
 extends ThermalSeparation.BalanceEquations.BaseNonEq.BaseBalanceEq;
 
 /*** changes to reduce index: fixed state selection ***/
-  output SI.MolarInternalEnergy u_v[n](stateSelect=StateSelect.always);
-  output SI.MolarInternalEnergy u_l[n](stateSelect=StateSelect.always);
-  Modelica.SIunits.AmountOfSubstance n_mol_L[n](stateSelect=StateSelect.always);
-  Modelica.SIunits.AmountOfSubstance n_mol_V[n](stateSelect=StateSelect.always);
-  Modelica.SIunits.AmountOfSubstance n_mol_L_i[n,nSL](stateSelect=StateSelect.always);
-  Modelica.SIunits.AmountOfSubstance n_mol_V_i[n,nSV](stateSelect=StateSelect.always);
+  output SI.MolarInternalEnergy u_v[n](stateSelect=StateSelect.prefer);
+  output SI.MolarInternalEnergy u_l[n](stateSelect=StateSelect.prefer);
+  Modelica.SIunits.AmountOfSubstance n_mol_L[n](stateSelect=StateSelect.prefer);
+  Modelica.SIunits.AmountOfSubstance n_mol_V[n](stateSelect=StateSelect.prefer);
+  Modelica.SIunits.AmountOfSubstance n_mol_L_i[n,nSL](stateSelect=StateSelect.prefer);
+  Modelica.SIunits.AmountOfSubstance n_mol_V_i[n,nSV](stateSelect=StateSelect.prefer);
   Modelica.SIunits.AmountOfSubstance n_mol[n,nS];
 
 equation

--- a/ThermalSeparation/BalanceEquations/BaseNonEq/NonEquilibrium/BaseTwoPhaseVarState.mo
+++ b/ThermalSeparation/BalanceEquations/BaseNonEq/NonEquilibrium/BaseTwoPhaseVarState.mo
@@ -7,7 +7,7 @@ extends ThermalSeparation.BalanceEquations.BaseNonEq.BaseBalanceEq;
   output SI.MolarInternalEnergy u_l[n](stateSelect=StateSelect.default);
 
 protected
-  Real eps_liq_state[n]( stateSelect=StateSelect.always)=eps_liq;
+  Real eps_liq_state[n]( stateSelect=StateSelect.prefer)=eps_liq;
 
 equation
 /*** MOLE BALANCES ***/

--- a/ThermalSeparation/Components/Columns/BaseClasses/BaseColumn_external.mo
+++ b/ThermalSeparation/Components/Columns/BaseClasses/BaseColumn_external.mo
@@ -153,7 +153,7 @@ replaceable package MediumLiquid =
           extent={{50,-100},{70,-80}}, rotation=0)));
 
   //initial equation for eps_liq is supplied in the extending class!
-  SI.VolumeFraction eps_liq[        n]( stateSelect=StateSelect.always)
+  SI.VolumeFraction eps_liq[        n]( stateSelect=StateSelect.prefer)
     "liquid volume fraction";
   SI.VolumeFraction eps_vap[        n](start=fill(0.99,n))
     "vapour volume fraction";

--- a/ThermalSeparation/Components/Columns/BaseClasses/package.mo
+++ b/ThermalSeparation/Components/Columns/BaseClasses/package.mo
@@ -154,7 +154,7 @@ package BaseClasses "base classes for columns"
               {80,-80}}, rotation=0), iconTransformation(extent={{60,-100},{80,-80}})));
 
     //initial equation for eps_liq is supplied in the extending class!
-    SI.VolumeFraction eps_liq[        n](each stateSelect=StateSelect.always) "liquid volume fraction";
+    SI.VolumeFraction eps_liq[        n](each stateSelect=StateSelect.prefer) "liquid volume fraction";
     SI.VolumeFraction eps_vap[        n](start=fill(0.99,n)) "vapour volume fraction";
     SI.Temperature T[n];
     SI.HeatFlowRate Qdot_wall[n] "heat flow rate to wall";

--- a/ThermalSeparation/Components/ColumnsNoIndex/BaseClasses/BaseColumn_external.mo
+++ b/ThermalSeparation/Components/ColumnsNoIndex/BaseClasses/BaseColumn_external.mo
@@ -88,7 +88,7 @@ replaceable package MediumLiquid =
   SI.MolarMass MM_v_in( start=0.03) = mediumVapourIn.MM;
   ThermalSeparation.Units.MolarEnthalpy h_v[n] = mediumVapour.h;
   ThermalSeparation.Units.MolarEnthalpy h_v_in = mediumVapourIn.h;
-  SI.MolarInternalEnergy u_v[n](stateSelect=StateSelect.always)= mediumVapour.u;
+  SI.MolarInternalEnergy u_v[n](stateSelect=StateSelect.prefer)= mediumVapour.u;
   SI.Concentration c_v_star[n,nSV];
   SI.Density rho_v_star[n] = mediumVapourStar.d;
 
@@ -102,7 +102,7 @@ replaceable package MediumLiquid =
   SI.MolarMass MM_l_star[n]= mediumLiquidStar.MM;
   ThermalSeparation.Units.MolarEnthalpy h_l[n]= mediumLiquid.h;
   ThermalSeparation.Units.MolarEnthalpy h_l_in=mediumLiquidIn.h;
-  SI.MolarInternalEnergy u_l[n](stateSelect=StateSelect.always) =  mediumLiquid.u;
+  SI.MolarInternalEnergy u_l[n](stateSelect=StateSelect.prefer) =  mediumLiquid.u;
 
 //Variables upStream
   SI.Concentration c_v_in[nSV];
@@ -293,10 +293,10 @@ Real check[nS-1];
 
 /*** changes to reduce index ***/
 Modelica.SIunits.AmountOfSubstance n_mol[n,nS];
-Modelica.SIunits.AmountOfSubstance n_mol_L[n](stateSelect=StateSelect.always);
-Modelica.SIunits.AmountOfSubstance n_mol_V[n](stateSelect=StateSelect.always);
-Real n_mol_L_i[n,nSL](stateSelect=StateSelect.always);
-Real n_mol_V_i[n,nSV](stateSelect=StateSelect.always);
+Modelica.SIunits.AmountOfSubstance n_mol_L[n](stateSelect=StateSelect.prefer);
+Modelica.SIunits.AmountOfSubstance n_mol_V[n](stateSelect=StateSelect.prefer);
+Real n_mol_L_i[n,nSL](stateSelect=StateSelect.prefer);
+Real n_mol_V_i[n,nSV](stateSelect=StateSelect.prefer);
 
 initial algorithm
 

--- a/ThermalSeparation/Components/GasLiquidVolumes/LSF_deltaP.mo
+++ b/ThermalSeparation/Components/GasLiquidVolumes/LSF_deltaP.mo
@@ -9,7 +9,7 @@ replaceable model PressureLoss =
 PressureLoss pressureLoss(zeta=zeta, p_in = p_hyd[1], p_out = p_hyd[2], eps_liq = eps_liq, rho_l = rho_l, rho_v = rho_v, d_HX = d_HX, length_HX = length_HX, d_tube=d_tube, Nw=Nw);
 parameter Real zeta =  8.6;
 
-SI.MolarMass MM_v_state(  stateSelect=StateSelect.always)=MM_v;
+SI.MolarMass MM_v_state(  stateSelect=StateSelect.prefer)=MM_v;
 equation
 
 /*** Der Gleichung für Druckverlust bei Umströmung von Rohrbündeln nachempfunden (VDI-Wärmeatlas), zeta wird allerdings als Parameter vorgegeben

--- a/ThermalSeparation/Components/HeatExchanger.mo
+++ b/ThermalSeparation/Components/HeatExchanger.mo
@@ -356,7 +356,7 @@ extends ThermalSeparation.Icons.Library.Red;
   Modelica.SIunits.Concentration c_l[nSL](start=c_l_start, each nominal=1e4);
   //Modelica.SIunits.Concentration c_l_in[nSL](start=c_l_start, each nominal=1e4);
   Modelica.SIunits.MoleFraction x_l[nSL];
-    ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.always,start=1e6);
+    ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.prefer,start=1e6);
     ThermalSeparation.Units.MolarEnthalpy u_l;
     Modelica.SIunits.MolarMass MM_l;
   Modelica.SIunits.MoleFraction x_l_in[nSL];
@@ -374,9 +374,9 @@ extends ThermalSeparation.Icons.Library.Red;
     Modelica.SIunits.Pressure p_in;
 
     parameter Boolean ss_c2=false "true if c_l[2] is to be a state";
-    Modelica.SIunits.Concentration dummy(stateSelect=StateSelect.always)=c_l[2] if
+    Modelica.SIunits.Concentration dummy(stateSelect=StateSelect.prefer)=c_l[2] if
          ss_c2;
-  //    SI.Concentration dummy2(stateSelect=StateSelect.always)=c_l[3] if ss_c2;
+  //    SI.Concentration dummy2(stateSelect=StateSelect.prefer)=c_l[3] if ss_c2;
 
   public
     Real a = Qdot_wall/(2500*max(1e-6,Vdot_l_in)*1000);

--- a/ThermalSeparation/Components/HeatExchanger/LiquidTube.mo
+++ b/ThermalSeparation/Components/HeatExchanger/LiquidTube.mo
@@ -35,7 +35,7 @@ SI.Density rho_l;
 parameter SI.Concentration c_l_start[nSL]={5,40000};
 SI.Concentration c_l[nSL](start = c_l_start, nominal = 1e4);
 SI.MoleFraction x_l[nSL];
-  ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.always,start=1e6);
+  ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.prefer,start=1e6);
   ThermalSeparation.Units.MolarEnthalpy u_l;
   SI.MolarMass MM_l;
   SI.Concentration c_l_in[nSL](nominal = 1e4);
@@ -54,8 +54,8 @@ SI.MoleFraction x_l_in[nSL];
   SI.Pressure p;//(stateSelect=StateSelect.prefer,start=2e5);
 
   parameter Boolean ss_c2=false "true if c_l[2] is to be a state";
-  SI.Concentration dummy(stateSelect=StateSelect.always)=c_l[2] if ss_c2;
-//    SI.Concentration dummy2(stateSelect=StateSelect.always)=c_l[3] if ss_c2;
+  SI.Concentration dummy(stateSelect=StateSelect.prefer)=c_l[2] if ss_c2;
+//    SI.Concentration dummy2(stateSelect=StateSelect.prefer)=c_l[3] if ss_c2;
 
 public
   Real a = Qdot_wall/(2500*Vdot_l_in*1000);

--- a/ThermalSeparation/Components/LiquidVolumes/Sump.mo
+++ b/ThermalSeparation/Components/LiquidVolumes/Sump.mo
@@ -36,10 +36,10 @@ ThermalSeparation.Media.WaterBasedLiquid.CO2_H2O     constrainedby
 
   SI.Density rho_l = mediumLiquid.d;
   SI.Concentration c_l[nSL];
-  Real dummy1(stateSelect=StateSelect.always)=c_l[1];
-  //Real dummy2(stateSelect=StateSelect.always)=c_l[2];
+  Real dummy1(stateSelect=StateSelect.prefer)=c_l[1];
+  //Real dummy2(stateSelect=StateSelect.prefer)=c_l[2];
    ThermalSeparation.Units.MolarEnthalpy h_l;//= mediumLiquid.h;
-   ThermalSeparation.Units.MolarEnthalpy u_l(stateSelect=StateSelect.always) = mediumLiquid.u;
+   ThermalSeparation.Units.MolarEnthalpy u_l(stateSelect=StateSelect.prefer) = mediumLiquid.u;
    SI.MolarMass MM_l = mediumLiquid.MM;
   SI.MoleFraction x_l[nSL];
 

--- a/ThermalSeparation/Components/LiquidVolumes/Tank.mo
+++ b/ThermalSeparation/Components/LiquidVolumes/Tank.mo
@@ -29,8 +29,8 @@ ThermalSeparation.Media.WaterBasedLiquid.CO2_H2O     constrainedby
 /*** Medium properties ***/
  SI.Density rho_l = mediumLiquid.d;
  SI.Density rho_l_in = mediumLiquidIn.d;
-  SI.Concentration dummy(stateSelect=StateSelect.always)=c_l[1];
-   ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.always);
+  SI.Concentration dummy(stateSelect=StateSelect.prefer)=c_l[1];
+   ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.prefer);
    ThermalSeparation.Units.MolarEnthalpy u_l = mediumLiquid.u;
    SI.MolarMass MM_l = mediumLiquid.MM;
    SI.MolarMass MM_l_in = mediumLiquidIn.MM;
@@ -43,7 +43,7 @@ ThermalSeparation.Media.WaterBasedLiquid.CO2_H2O     constrainedby
 
   /*** geometry data ***/
     final parameter SI.Area A= Modelica.Constants.pi/4* d_volume^2;
-  SI.Height level(stateSelect=StateSelect.always);
+  SI.Height level(stateSelect=StateSelect.prefer);
 
   parameter SI.Diameter d_volume = 0.025 "diameter of the tank";
   parameter Real zeta=2 "friction factor";

--- a/ThermalSeparation/Components/LiquidVolumes/Tank2Inlets.mo
+++ b/ThermalSeparation/Components/LiquidVolumes/Tank2Inlets.mo
@@ -31,9 +31,9 @@ ThermalSeparation.Media.WaterBasedLiquid.CO2_H2O     constrainedby
   SI.Density rho_l_in = mediumLiquidIn.d;
   SI.Density rho_l_in_recirc = mediumLiquidInRecirc.d;
  SI.Concentration c_l[nSL](each stateSelect=StateSelect.default);
-  SI.Concentration dummy(stateSelect=StateSelect.always)=c_l[1];
+  SI.Concentration dummy(stateSelect=StateSelect.prefer)=c_l[1];
  SI.MoleFraction x_l[nSL];
-   ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.always)= mediumLiquid.h;
+   ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.prefer)= mediumLiquid.h;
    ThermalSeparation.Units.MolarEnthalpy u_l = mediumLiquid.u;
 
  SI.MoleFraction x_l_in[nSL] = inStream(portIn.x_outflow);
@@ -50,7 +50,7 @@ ThermalSeparation.Media.WaterBasedLiquid.CO2_H2O     constrainedby
 
   /*** geometry data ***/
     final parameter SI.Area A= Modelica.Constants.pi/4* d_volume^2;
-  SI.Height level(stateSelect=StateSelect.always);
+  SI.Height level(stateSelect=StateSelect.prefer);
 
   parameter SI.Diameter d_volume = 0.025;
   parameter Real zeta=2;

--- a/ThermalSeparation/Components/LiquidVolumes/Tests.mo
+++ b/ThermalSeparation/Components/LiquidVolumes/Tests.mo
@@ -49,7 +49,7 @@ package Tests
 
     /*** geometry data ***/
       final parameter SI.Area A= Modelica.Constants.pi/4* d_volume^2;
-    SI.Height level(stateSelect=StateSelect.always);
+    SI.Height level(stateSelect=StateSelect.prefer);
 
     parameter SI.Length height_in = -0.15;
     parameter SI.Length length_out = 0.15;

--- a/ThermalSeparation/Components/LiquidVolumes/Volume.mo
+++ b/ThermalSeparation/Components/LiquidVolumes/Volume.mo
@@ -22,9 +22,9 @@ ThermalSeparation.Media.WaterBasedLiquid.CO2_H2O     constrainedby
 
 /*** Medium properties ***/
  SI.Density rho_l = mediumLiquid.d;
- // SI.Concentration dummy[nSL-1](stateSelect=StateSelect.always)={c_l[1],c_l[2]};
+ // SI.Concentration dummy[nSL-1](stateSelect=StateSelect.prefer)={c_l[1],c_l[2]};
    ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.default)= mediumLiquid.h;
-   ThermalSeparation.Units.MolarEnthalpy u_l(stateSelect=StateSelect.always) = mediumLiquid.u;
+   ThermalSeparation.Units.MolarEnthalpy u_l(stateSelect=StateSelect.prefer) = mediumLiquid.u;
    SI.MolarMass MM_l = mediumLiquid.MM;
         SI.Concentration x_l_in[nSL] = inStream(portIn.x_outflow);
    ThermalSeparation.Units.MolarEnthalpy h_l_in= mediumLiquidIn.h;
@@ -34,7 +34,7 @@ ThermalSeparation.Media.WaterBasedLiquid.CO2_H2O     constrainedby
    SI.MolarMass MM_l_in = mediumLiquidIn.MM;
 
     SI.Concentration c_l[nSL](each stateSelect=StateSelect.default);
-    SI.MoleFraction x_l[nSL](each stateSelect=StateSelect.always);
+    SI.MoleFraction x_l[nSL](each stateSelect=StateSelect.prefer);
   SI.Pressure p(start=2e5);
 
   /*** geometry data ***/

--- a/ThermalSeparation/Components/Reboiler/BaseClasses/BaseLSF.mo
+++ b/ThermalSeparation/Components/Reboiler/BaseClasses/BaseLSF.mo
@@ -87,7 +87,7 @@ parameter Boolean inertLiquid[nSL] = {false, false, true};
   ThermalSeparation.Units.MolarEnthalpy h_v = mediumVapour.h;
     ThermalSeparation.Units.MolarEnthalpy h_transfer_fromV= vapToFilmB.h;
   ThermalSeparation.Units.MolarEnthalpy h_transfer_toV= filmToVapB.h;
-  SI.MolarInternalEnergy u_v(stateSelect=StateSelect.always)= mediumVapour.u;
+  SI.MolarInternalEnergy u_v(stateSelect=StateSelect.prefer)= mediumVapour.u;
 
   /*** liquid properties ***/
   SI.Density rho_l = mediumLiquid.d "density of the liquid, all components";
@@ -101,14 +101,14 @@ parameter Boolean inertLiquid[nSL] = {false, false, true};
   ThermalSeparation.Units.MolarEnthalpy h_l_in=mediumLiquidIn.h;
     ThermalSeparation.Units.MolarEnthalpy h_transfer_fromL= liqToFilmB.h;
   ThermalSeparation.Units.MolarEnthalpy h_transfer_toL= filmToVapB.h;
-  SI.MolarInternalEnergy u_l(stateSelect=StateSelect.always) =  mediumLiquid.u;
+  SI.MolarInternalEnergy u_l(stateSelect=StateSelect.prefer) =  mediumLiquid.u;
 
 /*** Medium properties ***/
-SI.Concentration c_l[nSL](stateSelect=StateSelect.always) annotation(Dialog(group="Initialization",showStartAttribute=true));
+SI.Concentration c_l[nSL](stateSelect=StateSelect.prefer) annotation(Dialog(group="Initialization",showStartAttribute=true));
 SI.MoleFraction x_l[nSL];
   SI.Concentration c_l_in[nSL];
 SI.MoleFraction x_l_in[nSL];
-SI.Concentration c_v[nSV](stateSelect=StateSelect.always) annotation(Dialog(group="Initialization",showStartAttribute=true));
+SI.Concentration c_v[nSV](stateSelect=StateSelect.prefer) annotation(Dialog(group="Initialization",showStartAttribute=true));
 SI.MoleFraction x_v[nSV];
   SI.Concentration c_l_star[nSL];
     SI.Temperature T_l_in;
@@ -119,7 +119,7 @@ SI.MoleFraction x_v[nSV];
   SI.VolumeFlowRate Vdot_l;
   SI.VolumeFlowRate Vdot_l_in(start=1e-4);
 
-  Real eps_liq(stateSelect=StateSelect.always);
+  Real eps_liq(stateSelect=StateSelect.prefer);
   Real eps_vap;
 
     SI.MolarFlowRate Ndot_v_transfer[      nSV](start=fill(-0.1,nSV));

--- a/ThermalSeparation/Components/Reboiler/BaseClasses/BaseReboiler.mo
+++ b/ThermalSeparation/Components/Reboiler/BaseClasses/BaseReboiler.mo
@@ -62,7 +62,7 @@ parameter Boolean inertLiquid[nSL] = {false, false, true};
   ThermalSeparation.Units.MolarEnthalpy h_v = mediumVapour.h;
     ThermalSeparation.Units.MolarEnthalpy h_transfer_fromV= vapToFilmB.h;
   ThermalSeparation.Units.MolarEnthalpy h_transfer_toV= filmToVapB.h;
-  SI.MolarInternalEnergy u_v(stateSelect=StateSelect.always)= mediumVapour.u;
+  SI.MolarInternalEnergy u_v(stateSelect=StateSelect.prefer)= mediumVapour.u;
 
   /*** liquid properties ***/
   SI.Density rho_l = mediumLiquid.d "density of the liquid, all components";
@@ -76,25 +76,25 @@ parameter Boolean inertLiquid[nSL] = {false, false, true};
   ThermalSeparation.Units.MolarEnthalpy h_l_in=mediumLiquidIn.h;
     ThermalSeparation.Units.MolarEnthalpy h_transfer_fromL= liqToFilmB.h;
   ThermalSeparation.Units.MolarEnthalpy h_transfer_toL= filmToVapB.h;
-  SI.MolarInternalEnergy u_l(stateSelect=StateSelect.always) =  mediumLiquid.u;
+  SI.MolarInternalEnergy u_l(stateSelect=StateSelect.prefer) =  mediumLiquid.u;
 
 /*** Medium properties ***/
-SI.Concentration c_l[nSL](stateSelect=StateSelect.always) annotation(Dialog(group="Initialization",showStartAttribute=true));
+SI.Concentration c_l[nSL](stateSelect=StateSelect.prefer) annotation(Dialog(group="Initialization",showStartAttribute=true));
 SI.MoleFraction x_l[nSL](start=x_l_start);
   SI.Concentration c_l_in[nSL];
 SI.MoleFraction x_l_in[nSL];
-SI.Concentration c_v[nSV](stateSelect=StateSelect.always) annotation(Dialog(group="Initialization",showStartAttribute=true));
+SI.Concentration c_v[nSV](stateSelect=StateSelect.prefer) annotation(Dialog(group="Initialization",showStartAttribute=true));
 SI.MoleFraction x_v[nSV];
   SI.Concentration c_l_star[nSL];
     SI.Temperature T_l_in;
   SI.Temperature T_l;
-  SI.Temperature T_v(stateSelect=StateSelect.always);
+  SI.Temperature T_v(stateSelect=StateSelect.prefer);
 
   SI.VolumeFlowRate Vdot_v(start=1e-4);
   SI.VolumeFlowRate Vdot_l;
   SI.VolumeFlowRate Vdot_l_in(start=1e-4);
 
-  Real eps_liq(stateSelect=StateSelect.always);
+  Real eps_liq(stateSelect=StateSelect.prefer);
   Real eps_vap;
 
     SI.MolarFlowRate Ndot_v_transfer[      nSV](start=fill(-0.1,nSV));

--- a/ThermalSeparation/Components/Reboiler/BaseClasses/BaseReboiler2.mo
+++ b/ThermalSeparation/Components/Reboiler/BaseClasses/BaseReboiler2.mo
@@ -76,10 +76,10 @@ parameter Boolean inertLiquid[nSL] = {false, false, true};
   ThermalSeparation.Units.MolarEnthalpy h_l_in=mediumLiquidIn.h;
     ThermalSeparation.Units.MolarEnthalpy h_transfer_fromL= liqToFilmB.h;
   ThermalSeparation.Units.MolarEnthalpy h_transfer_toL= filmToVapB.h;
-  SI.MolarInternalEnergy u_l(stateSelect=StateSelect.always) =  mediumLiquid.u;
+  SI.MolarInternalEnergy u_l(stateSelect=StateSelect.prefer) =  mediumLiquid.u;
 
 /*** Medium properties ***/
-SI.Concentration c_l[nSL](stateSelect=StateSelect.always) annotation(Dialog(group="Initialization",showStartAttribute=true));
+SI.Concentration c_l[nSL](stateSelect=StateSelect.prefer) annotation(Dialog(group="Initialization",showStartAttribute=true));
 SI.MoleFraction x_l[nSL](start=x_l_start);
   SI.Concentration c_l_in[nSL];
 SI.MoleFraction x_l_in[nSL];
@@ -88,13 +88,13 @@ SI.MoleFraction x_v[nSV];
   SI.Concentration c_l_star[nSL];
     SI.Temperature T_l_in;
   SI.Temperature T_l;
-  SI.Temperature T_v(stateSelect=StateSelect.always);
+  SI.Temperature T_v(stateSelect=StateSelect.prefer);
 
   SI.VolumeFlowRate Vdot_v(start=1e-4);
   SI.VolumeFlowRate Vdot_l;
   SI.VolumeFlowRate Vdot_l_in(start=1e-4);
 
-  Real eps_liq(stateSelect=StateSelect.always);
+  Real eps_liq(stateSelect=StateSelect.prefer);
   Real eps_vap;
 
     SI.MolarFlowRate Ndot_v_transfer[      nSV](start=fill(-0.1,nSV));

--- a/ThermalSeparation/Components/Reboiler/BaseClasses/BaseReboiler_test.mo
+++ b/ThermalSeparation/Components/Reboiler/BaseClasses/BaseReboiler_test.mo
@@ -52,7 +52,7 @@ parameter Boolean inertLiquid[nSL] = {false, false, true};
     "molar mass of the vapour mixture ";
   ThermalSeparation.Units.MolarEnthalpy h_v = mediumVapour.h;
 
-  SI.MolarInternalEnergy u_v(stateSelect=StateSelect.always)= mediumVapour.u;
+  SI.MolarInternalEnergy u_v(stateSelect=StateSelect.prefer)= mediumVapour.u;
 
   /*** liquid properties ***/
   SI.Density rho_l = mediumLiquid.d "density of the liquid, all components";
@@ -64,24 +64,24 @@ parameter Boolean inertLiquid[nSL] = {false, false, true};
   ThermalSeparation.Units.MolarEnthalpy h_l= mediumLiquid.h;
   ThermalSeparation.Units.MolarEnthalpy h_l_in=mediumLiquidIn.h;
 
-  SI.MolarInternalEnergy u_l(stateSelect=StateSelect.always) =  mediumLiquid.u;
+  SI.MolarInternalEnergy u_l(stateSelect=StateSelect.prefer) =  mediumLiquid.u;
 
 /*** Medium properties ***/
-SI.Concentration c_l[nSL](stateSelect=StateSelect.always);
+SI.Concentration c_l[nSL](stateSelect=StateSelect.prefer);
 SI.MoleFraction x_l[nSL](start=x_l_start);
   SI.Concentration c_l_in[nSL];
 SI.MoleFraction x_l_in[nSL];
-SI.Concentration c_v[nSV](stateSelect=StateSelect.always);
+SI.Concentration c_v[nSV](stateSelect=StateSelect.prefer);
 SI.MoleFraction x_v[nSV];
     SI.Temperature T_l_in;
   SI.Temperature T_l;
-  SI.Temperature T_v(stateSelect=StateSelect.always);
+  SI.Temperature T_v(stateSelect=StateSelect.prefer);
 
   SI.VolumeFlowRate Vdot_v(start=1e-4);
   SI.VolumeFlowRate Vdot_l;
   SI.VolumeFlowRate Vdot_l_in(start=1e-4);
 
-  Real eps_liq(stateSelect=StateSelect.always);
+  Real eps_liq(stateSelect=StateSelect.prefer);
   Real eps_vap;
 
    SI.MoleFraction x_l_star[nSL](start=x_l_start);

--- a/ThermalSeparation/Components/Reboiler/BaseClasses/BaseReboiler_test2.mo
+++ b/ThermalSeparation/Components/Reboiler/BaseClasses/BaseReboiler_test2.mo
@@ -52,7 +52,7 @@ parameter Boolean inertLiquid[nSL] = {false, false, true} annotation(evaluate=tr
     "molar mass of the vapour mixture ";
   ThermalSeparation.Units.MolarEnthalpy h_v = mediumVapour.h;
 
-  SI.MolarInternalEnergy u_v(stateSelect=StateSelect.always)= mediumVapour.u;
+  SI.MolarInternalEnergy u_v(stateSelect=StateSelect.prefer)= mediumVapour.u;
 
   /*** liquid properties ***/
   SI.Density rho_l = mediumLiquid.d "density of the liquid, all components";
@@ -64,24 +64,24 @@ parameter Boolean inertLiquid[nSL] = {false, false, true} annotation(evaluate=tr
   ThermalSeparation.Units.MolarEnthalpy h_l= mediumLiquid.h;
   ThermalSeparation.Units.MolarEnthalpy h_l_in=mediumLiquidIn.h;
 
-  SI.MolarInternalEnergy u_l(stateSelect=StateSelect.always) =  mediumLiquid.u;
+  SI.MolarInternalEnergy u_l(stateSelect=StateSelect.prefer) =  mediumLiquid.u;
 
 /*** Medium properties ***/
-SI.Concentration c_l[nSL](stateSelect=StateSelect.always);
+SI.Concentration c_l[nSL](stateSelect=StateSelect.prefer);
 SI.MoleFraction x_l[nSL](start=x_l_start);
   SI.Concentration c_l_in[nSL];
 SI.MoleFraction x_l_in[nSL];
-SI.Concentration c_v[nSV](stateSelect=StateSelect.always);
+SI.Concentration c_v[nSV](stateSelect=StateSelect.prefer);
 SI.MoleFraction x_v[nSV];
     SI.Temperature T_l_in;
   SI.Temperature T_l;
-  SI.Temperature T_v(stateSelect=StateSelect.always);
+  SI.Temperature T_v(stateSelect=StateSelect.prefer);
 
   SI.VolumeFlowRate Vdot_v(start=1e-4);
   SI.VolumeFlowRate Vdot_l;
   SI.VolumeFlowRate Vdot_l_in(start=1e-4);
 
-  Real eps_liq(stateSelect=StateSelect.always);
+  Real eps_liq(stateSelect=StateSelect.prefer);
   Real eps_vap;
 
    SI.MoleFraction x_l_star[nSL](start=x_l_start);

--- a/ThermalSeparation/Components/Reboiler/KettleReboilerEq.mo
+++ b/ThermalSeparation/Components/Reboiler/KettleReboilerEq.mo
@@ -48,7 +48,7 @@ model KettleReboilerEq "equilibrium model"
   Modelica.SIunits.MolarFlowRate F_out_l(start=1e-4);
   Modelica.SIunits.MolarFlowRate F_out_v(start=1e-4);
 
-  Modelica.SIunits.AmountOfSubstance HU_l(start=1000, stateSelect=StateSelect.always);
+  Modelica.SIunits.AmountOfSubstance HU_l(start=1000, stateSelect=StateSelect.prefer);
   Modelica.SIunits.AmountOfSubstance HU_v(start=100);
 
   replaceable package MediumVapour = ThermalSeparation.Media.C2H5OH_Water_Vap
@@ -126,7 +126,7 @@ Modelica.SIunits.MolarFlowRate Ndot_l_transfer[nSL];
   ThermalSeparation.Units.MolarEnthalpy h_v = mediumVapour.h;
   ThermalSeparation.Units.MolarEnthalpy h_l;// = mediumLiquid.h;
   ThermalSeparation.Units.MolarEnthalpy h_feed = 0; //simplification
-  ThermalSeparation.Units.MolarEnthalpy u_l(stateSelect=StateSelect.always) = mediumLiquid.u;
+  ThermalSeparation.Units.MolarEnthalpy u_l(stateSelect=StateSelect.prefer) = mediumLiquid.u;
   ThermalSeparation.Units.MolarEnthalpy u_v = mediumVapour.u;
 
   Modelica.SIunits.MolarMass MM_l=mediumLiquid.MM;
@@ -144,7 +144,7 @@ Modelica.SIunits.MolarFlowRate Ndot_l_transfer[nSL];
   Modelica.SIunits.Volume V_abs;
 
   Modelica.SIunits.Concentration c_l[nSL];
-  Real dummy_c_l(stateSelect=StateSelect.always)=c_l[2];
+  Real dummy_c_l(stateSelect=StateSelect.prefer)=c_l[2];
   Modelica.SIunits.Concentration c_v[nSV];
 
   Modelica.SIunits.VolumeFlowRate vdot_l;

--- a/ThermalSeparation/Components/Reboiler/Reboiler.mo
+++ b/ThermalSeparation/Components/Reboiler/Reboiler.mo
@@ -76,10 +76,10 @@ parameter Boolean inertLiquid[nSL] = {false, false, true};
   ThermalSeparation.Units.MolarEnthalpy h_l_in;//=mediumLiquidIn.h;
     ThermalSeparation.Units.MolarEnthalpy h_transfer_fromL= liqToFilmB.h;
   ThermalSeparation.Units.MolarEnthalpy h_transfer_toL= filmToVapB.h;
-  SI.MolarInternalEnergy u_l(stateSelect=StateSelect.always) =  mediumLiquid.u;
+  SI.MolarInternalEnergy u_l(stateSelect=StateSelect.prefer) =  mediumLiquid.u;
 
 /*** Medium properties ***/
-SI.Concentration c_l[nSL](each stateSelect=StateSelect.always) annotation(Dialog(group="Initialization",showStartAttribute=true));
+SI.Concentration c_l[nSL](each stateSelect=StateSelect.prefer) annotation(Dialog(group="Initialization",showStartAttribute=true));
 SI.MoleFraction x_l[nSL](start=x_l_start);
 
 SI.MoleFraction x_l_in[nSL];
@@ -88,12 +88,12 @@ SI.MoleFraction x_v[nSV];
   SI.Concentration c_l_star[nSL];
     SI.Temperature T_l_in;
   SI.Temperature T_l;
-  SI.Temperature T_v(stateSelect=StateSelect.always);
+  SI.Temperature T_v(stateSelect=StateSelect.prefer);
 
   SI.VolumeFlowRate Vdot_v(start=1e-4);
   SI.VolumeFlowRate Vdot_l;
 
-  Real eps_liq(stateSelect=StateSelect.always);
+  Real eps_liq(stateSelect=StateSelect.prefer);
   Real eps_vap;
 
     SI.MolarFlowRate Ndot_v_transfer[      nSV](start=fill(-0.1,nSV));

--- a/ThermalSeparation/Components/Reboiler/package.mo
+++ b/ThermalSeparation/Components/Reboiler/package.mo
@@ -150,9 +150,9 @@ package Reboiler "this package contains components which have both a liquid and 
   SI.Concentration c_liq[nL];
   SI.Concentration c_vap[nV];
 
-  Real dummy(stateSelect=StateSelect.always);
-  Real dummy2(stateSelect=StateSelect.always);
-  Real dummy3(stateSelect=StateSelect.always);
+  Real dummy(stateSelect=StateSelect.prefer);
+  Real dummy2(stateSelect=StateSelect.prefer);
+  Real dummy3(stateSelect=StateSelect.prefer);
 
   //molar fractions of liquid and gas phase
   SI.MoleFraction y[nV](start=fill(1/nV,nV));

--- a/ThermalSeparation/Components/Tanks/Tank.mo
+++ b/ThermalSeparation/Components/Tanks/Tank.mo
@@ -31,9 +31,9 @@ ThermalSeparation.Media.ModelicaMedia.Water.Absorption.CO2_H2O
   SI.Density rho_l_in = mediumLiquidIn.d;
   SI.Density rho_l_in_recirc = mediumLiquidInRecirc.d;
  SI.Concentration c_l[nSL](stateSelect=StateSelect.default);
-  SI.Concentration dummy(stateSelect=StateSelect.always)=c_l[1];
+  SI.Concentration dummy(stateSelect=StateSelect.prefer)=c_l[1];
  SI.MoleFraction x_l[nSL];
-   ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.always)= mediumLiquid.h;
+   ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.prefer)= mediumLiquid.h;
    ThermalSeparation.Units.MolarEnthalpy u_l = mediumLiquid.u;
    SI.Concentration c_l_in[nSL];
       SI.Concentration c_l_in_recirc[nSL];
@@ -50,7 +50,7 @@ ThermalSeparation.Media.ModelicaMedia.Water.Absorption.CO2_H2O
 
   /*** geometry data ***/
     final parameter SI.Area A= Modelica.Constants.pi/4* d_volume^2;
-  SI.Height level(stateSelect=StateSelect.always);
+  SI.Height level(stateSelect=StateSelect.prefer);
 
   parameter SI.Diameter d_volume = 0.025;
   parameter Real zeta=2;

--- a/ThermalSeparation/Components/Tanks/Tank2.mo
+++ b/ThermalSeparation/Components/Tanks/Tank2.mo
@@ -28,8 +28,8 @@ ThermalSeparation.Media.ModelicaMedia.Water.Absorption.CO2_H2O
 /*** Medium properties ***/
  SI.Density rho_l = mediumLiquid.d;
  SI.Density rho_l_in = mediumLiquidIn.d;
-  SI.Concentration dummy(stateSelect=StateSelect.always)=c_l[1];
-   ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.always)= mediumLiquid.h;
+  SI.Concentration dummy(stateSelect=StateSelect.prefer)=c_l[1];
+   ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.prefer)= mediumLiquid.h;
    ThermalSeparation.Units.MolarEnthalpy u_l = mediumLiquid.u;
    SI.MolarMass MM_l = mediumLiquid.MM;
    SI.MolarMass MM_l_in = mediumLiquidIn.MM;
@@ -42,7 +42,7 @@ ThermalSeparation.Media.ModelicaMedia.Water.Absorption.CO2_H2O
 
   /*** geometry data ***/
     final parameter SI.Area A= Modelica.Constants.pi/4* d_volume^2;
-  SI.Height level(stateSelect=StateSelect.always);
+  SI.Height level(stateSelect=StateSelect.prefer);
 
   parameter SI.Diameter d_volume = 0.025;
   parameter Real zeta=2;

--- a/ThermalSeparation/Components/Tanks/Volume.mo
+++ b/ThermalSeparation/Components/Tanks/Volume.mo
@@ -23,9 +23,9 @@ ThermalSeparation.Media.ModelicaMedia.Water.Absorption.CO2_H2O
 
 /*** Medium properties ***/
  SI.Density rho_l = mediumLiquid.d;
- // SI.Concentration dummy[nSL-1](stateSelect=StateSelect.always)={c_l[1],c_l[2]};
+ // SI.Concentration dummy[nSL-1](stateSelect=StateSelect.prefer)={c_l[1],c_l[2]};
    ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.default)= mediumLiquid.h;
-   ThermalSeparation.Units.MolarEnthalpy u_l(stateSelect=StateSelect.always) = mediumLiquid.u;
+   ThermalSeparation.Units.MolarEnthalpy u_l(stateSelect=StateSelect.prefer) = mediumLiquid.u;
    SI.MolarMass MM_l = mediumLiquid.MM;
         SI.Concentration c_l_in[nSL] = portIn.c;
    ThermalSeparation.Units.MolarEnthalpy h_l_in= mediumLiquidIn.h;
@@ -33,7 +33,7 @@ ThermalSeparation.Media.ModelicaMedia.Water.Absorption.CO2_H2O
    SI.MolarMass MM_l_in = mediumLiquidIn.MM;
 
     SI.Concentration c_l[nSL](stateSelect=StateSelect.default);
-    SI.MoleFraction x_l[nSL](stateSelect=StateSelect.always);
+    SI.MoleFraction x_l[nSL](stateSelect=StateSelect.prefer);
   SI.Pressure p(start=2e5);
   SI.VolumeFlowRate Vdot_l_out;
 

--- a/ThermalSeparation/Components/Tanks/VolumeBreak.mo
+++ b/ThermalSeparation/Components/Tanks/VolumeBreak.mo
@@ -23,9 +23,9 @@ ThermalSeparation.Media.ModelicaMedia.Water.Absorption.CO2_H2O
 
 /*** Medium properties ***/
  SI.Density rho_l = mediumLiquid.d;
- // SI.Concentration dummy[nSL-1](stateSelect=StateSelect.always)={c_l[1],c_l[2]};
+ // SI.Concentration dummy[nSL-1](stateSelect=StateSelect.prefer)={c_l[1],c_l[2]};
    ThermalSeparation.Units.MolarEnthalpy h_l(stateSelect=StateSelect.default)= mediumLiquid.h;
-   ThermalSeparation.Units.MolarEnthalpy u_l(stateSelect=StateSelect.always) = mediumLiquid.u;
+   ThermalSeparation.Units.MolarEnthalpy u_l(stateSelect=StateSelect.prefer) = mediumLiquid.u;
    SI.MolarMass MM_l = mediumLiquid.MM;
         SI.Concentration c_l_in[nSL] = portIn.c;
    ThermalSeparation.Units.MolarEnthalpy h_l_in= mediumLiquidIn.h;
@@ -33,7 +33,7 @@ ThermalSeparation.Media.ModelicaMedia.Water.Absorption.CO2_H2O
    SI.MolarMass MM_l_in = mediumLiquidIn.MM;
 
     SI.Concentration c_l[nSL](stateSelect=StateSelect.default);
-    SI.MoleFraction x_l[nSL](stateSelect=StateSelect.always);
+    SI.MoleFraction x_l[nSL](stateSelect=StateSelect.prefer);
   SI.Pressure p(start=2e5);
   SI.VolumeFlowRate Vdot_l_out;
 

--- a/ThermalSeparation/FilmModel/BaseClasses/StateSelection.mo
+++ b/ThermalSeparation/FilmModel/BaseClasses/StateSelection.mo
@@ -23,22 +23,22 @@ package StateSelection
     model StateSelection1 "states: c_v, c_l, u_v, u_l, T_v"
       extends
         ThermalSeparation.FilmModel.BaseClasses.StateSelection.StateSelectionNoneq.BaseStateSelectionNoneq;
-       SI.Concentration c_v_state[n,nSV](each stateSelect=StateSelect.always)= propsVap.c;
-       SI.Concentration c_l_state[n,nSL](each stateSelect=StateSelect.always) = c_l;
-       SI.Concentration u_v_state[n](each stateSelect=StateSelect.always) = propsVap.u;
-       SI.Concentration u_l_state[n](each stateSelect=StateSelect.always) = propsLiq.u;
-       SI.Concentration T_v_state[n](each stateSelect=StateSelect.always) = propsVap.T;
+       SI.Concentration c_v_state[n,nSV](each stateSelect=StateSelect.prefer)= propsVap.c;
+       SI.Concentration c_l_state[n,nSL](each stateSelect=StateSelect.prefer) = c_l;
+       SI.Concentration u_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.u;
+       SI.Concentration u_l_state[n](each stateSelect=StateSelect.prefer) = propsLiq.u;
+       SI.Concentration T_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.T;
 
     end StateSelection1;
 
     model StateSelection2 "states: c_v, c_l, u_v, u_l, MM_v"
       extends
         ThermalSeparation.FilmModel.BaseClasses.StateSelection.StateSelectionNoneq.BaseStateSelectionNoneq;
-      SI.Concentration c_v_state[n,nSV](each stateSelect=StateSelect.always) = propsVap.c;
-      SI.Concentration c_l_state[n,nSL](each stateSelect=StateSelect.always) = c_l;
-      SI.Concentration u_v_state[n](each stateSelect=StateSelect.always) = propsVap.u;
-      SI.Concentration u_l_state[n](each stateSelect=StateSelect.always) = propsLiq.u;
-      SI.Concentration MM_v_state[n](each stateSelect=StateSelect.always) = propsVap.MM;
+      SI.Concentration c_v_state[n,nSV](each stateSelect=StateSelect.prefer) = propsVap.c;
+      SI.Concentration c_l_state[n,nSL](each stateSelect=StateSelect.prefer) = c_l;
+      SI.Concentration u_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.u;
+      SI.Concentration u_l_state[n](each stateSelect=StateSelect.prefer) = propsLiq.u;
+      SI.Concentration MM_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.MM;
     equation
 
     end StateSelection2;
@@ -52,11 +52,11 @@ package StateSelection
     model ReactionEquilibrium "states: c_v, c_l[1:nSL-1], u_v, u_l, MM_v"
       extends
         ThermalSeparation.FilmModel.BaseClasses.StateSelection.StateSelectionNoneq.BaseStateSelectionNoneq;
-      SI.Concentration c_v_state[n,nSV](each stateSelect=StateSelect.always) = propsVap.c;
-      SI.Concentration c_l_state[n,nSL-1](each stateSelect=StateSelect.always) = c_l[:,1:nSL-1];
-      SI.Concentration u_v_state[n](each stateSelect=StateSelect.always) = propsVap.u;
-      SI.Concentration u_l_state[n](each stateSelect=StateSelect.always) = propsLiq.u;
-      SI.Concentration MM_v_state[n](each stateSelect=StateSelect.always) = propsVap.MM;
+      SI.Concentration c_v_state[n,nSV](each stateSelect=StateSelect.prefer) = propsVap.c;
+      SI.Concentration c_l_state[n,nSL-1](each stateSelect=StateSelect.prefer) = c_l[:,1:nSL-1];
+      SI.Concentration u_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.u;
+      SI.Concentration u_l_state[n](each stateSelect=StateSelect.prefer) = propsLiq.u;
+      SI.Concentration MM_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.MM;
     equation
 
     end ReactionEquilibrium;
@@ -64,13 +64,13 @@ package StateSelection
     model StateSelection3 "states: x_v, x_l, p_v, T_l, T_v"
       extends
         ThermalSeparation.FilmModel.BaseClasses.StateSelection.StateSelectionNoneq.BaseStateSelectionNoneq;
-       SI.Concentration x_v_state[n,nSV](each stateSelect=StateSelect.always) = propsVap.x;
-       SI.Concentration x_l_state[n,nSL](each stateSelect=StateSelect.always) = propsLiq.x;
-       SI.Concentration p_v_state[n](each stateSelect=StateSelect.always) = p_v[1:n];
-       SI.Concentration T_l_state[n](each stateSelect=StateSelect.always) = propsLiq.T;
-       SI.Concentration T_v_state[n](each stateSelect=StateSelect.always) = propsVap.T;
+       SI.Concentration x_v_state[n,nSV](each stateSelect=StateSelect.prefer) = propsVap.x;
+       SI.Concentration x_l_state[n,nSL](each stateSelect=StateSelect.prefer) = propsLiq.x;
+       SI.Concentration p_v_state[n](each stateSelect=StateSelect.prefer) = p_v[1:n];
+       SI.Concentration T_l_state[n](each stateSelect=StateSelect.prefer) = propsLiq.T;
+       SI.Concentration T_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.T;
 
-     //  Real c_v_state[n](each stateSelect=StateSelect.always);
+     //  Real c_v_state[n](each stateSelect=StateSelect.prefer);
 
     equation
     for j in 1:n loop
@@ -103,45 +103,45 @@ package StateSelection
     model SaturatorAbsober "SprayAbsober"
       extends
         ThermalSeparation.FilmModel.BaseClasses.StateSelection.StateSelectionEq.BaseStateSelectionEq;
-       SI.Concentration u_v_state[n](each stateSelect=StateSelect.always) = propsVap.u;
-       SI.Concentration u_l_state[n](each stateSelect=StateSelect.always) = propsLiq.u;
-      SI.Pressure p_v_state[n](each stateSelect=StateSelect.always)= p_v;
-     SI.Concentration c_l_state_1[n](each stateSelect=StateSelect.always) = c_l[:,2];
-    // SI.Concentration c_l_state_2[n](each stateSelect=StateSelect.always) = c_l[:,3];
-        SI.Concentration T_v_state[n](each stateSelect=StateSelect.always) = propsVap.T;
+       SI.Concentration u_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.u;
+       SI.Concentration u_l_state[n](each stateSelect=StateSelect.prefer) = propsLiq.u;
+      SI.Pressure p_v_state[n](each stateSelect=StateSelect.prefer)= p_v;
+     SI.Concentration c_l_state_1[n](each stateSelect=StateSelect.prefer) = c_l[:,2];
+    // SI.Concentration c_l_state_2[n](each stateSelect=StateSelect.prefer) = c_l[:,3];
+        SI.Concentration T_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.T;
 
     end SaturatorAbsober;
 
     model SprayAbsober "SprayAbsober"
       extends
         ThermalSeparation.FilmModel.BaseClasses.StateSelection.StateSelectionEq.BaseStateSelectionEq;
-       SI.Concentration u_v_state[n](each stateSelect=StateSelect.always) = propsVap.u;
-       SI.Concentration u_l_state[n](each stateSelect=StateSelect.always) = propsLiq.u;
-      SI.Pressure p_v_state[n](each stateSelect=StateSelect.always)= p_v;
-     SI.Concentration c_l_state_3[n](each stateSelect=StateSelect.always) = c_l[:,2];
-        SI.Concentration T_v_state[n](each stateSelect=StateSelect.always) = propsVap.T;
+       SI.Concentration u_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.u;
+       SI.Concentration u_l_state[n](each stateSelect=StateSelect.prefer) = propsLiq.u;
+      SI.Pressure p_v_state[n](each stateSelect=StateSelect.prefer)= p_v;
+     SI.Concentration c_l_state_3[n](each stateSelect=StateSelect.prefer) = c_l[:,2];
+        SI.Concentration T_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.T;
 
     end SprayAbsober;
 
     model StateSelection3 "states: u_v, c_l, p_v "
       extends
         ThermalSeparation.FilmModel.BaseClasses.StateSelection.StateSelectionEq.BaseStateSelectionEq;
-      // SI.Concentration c_l_state[n,nSL](stateSelect=StateSelect.always) = c_l;
-       SI.Concentration u_v_state[n](each stateSelect=StateSelect.always) = propsVap.u;
-       SI.Concentration u_l_state[n](each stateSelect=StateSelect.always) = propsLiq.u;
-      SI.Pressure p_v_state[n](each stateSelect=StateSelect.always)= p_v;
+      // SI.Concentration c_l_state[n,nSL](stateSelect=StateSelect.prefer) = c_l;
+       SI.Concentration u_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.u;
+       SI.Concentration u_l_state[n](each stateSelect=StateSelect.prefer) = propsLiq.u;
+      SI.Pressure p_v_state[n](each stateSelect=StateSelect.prefer)= p_v;
 
-     //  SI.Concentration T_v_state[n](each stateSelect=StateSelect.always) = propsVap.T;
+     //  SI.Concentration T_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.T;
 
     end StateSelection3;
 
     model StateSelection4 "states: c_l, T_v , u_l"
       extends
         ThermalSeparation.FilmModel.BaseClasses.StateSelection.StateSelectionEq.BaseStateSelectionEq;
-       SI.Concentration c_l_state[n,nSL](each stateSelect=StateSelect.always) = c_l;
-       SI.Concentration u_l_state[n](each stateSelect=StateSelect.always) = propsLiq.u;
+       SI.Concentration c_l_state[n,nSL](each stateSelect=StateSelect.prefer) = c_l;
+       SI.Concentration u_l_state[n](each stateSelect=StateSelect.prefer) = propsLiq.u;
 
-          SI.Concentration T_v_state[n](each stateSelect=StateSelect.always) = propsVap.T;
+          SI.Concentration T_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.T;
 
     end StateSelection4;
 
@@ -154,12 +154,12 @@ package StateSelection
     model MA "MA"
       extends
         ThermalSeparation.FilmModel.BaseClasses.StateSelection.StateSelectionEq.BaseStateSelectionEq;
-       SI.Concentration u_v_state[n](each stateSelect=StateSelect.always) = propsVap.u;
-       SI.Concentration u_l_state[n](each stateSelect=StateSelect.always) = propsLiq.u;
-      SI.Pressure p_v_state[n](each stateSelect=StateSelect.always)= p_v;
-     SI.Concentration c_l_state_1[n](each stateSelect=StateSelect.always) = c_l[:,2];
-     SI.Concentration c_l_state_2[n](each stateSelect=StateSelect.always) = c_l[:,3];
-      SI.Concentration c_l_state_3[n](each stateSelect=StateSelect.always) = c_l[:,4];
+       SI.Concentration u_v_state[n](each stateSelect=StateSelect.prefer) = propsVap.u;
+       SI.Concentration u_l_state[n](each stateSelect=StateSelect.prefer) = propsLiq.u;
+      SI.Pressure p_v_state[n](each stateSelect=StateSelect.prefer)= p_v;
+     SI.Concentration c_l_state_1[n](each stateSelect=StateSelect.prefer) = c_l[:,2];
+     SI.Concentration c_l_state_2[n](each stateSelect=StateSelect.prefer) = c_l[:,3];
+      SI.Concentration c_l_state_3[n](each stateSelect=StateSelect.prefer) = c_l[:,4];
 
     end MA;
   end StateSelectionEq;

--- a/ThermalSeparation/Wall/BaseWall.mo
+++ b/ThermalSeparation/Wall/BaseWall.mo
@@ -21,7 +21,7 @@ partial model BaseWall "Model of the heat loss at the column outer wall"
     "heat transfer coefficient at inner side of the wall";
 //Dummy temperature which is needed in order to use the temperature as state if the wall is not calculated steady-state
 protected
-  SI.Temperature T_dummy[n](each stateSelect=StateSelect.always, start=fill(T_start,n)) = T_wall if not stat;
+  SI.Temperature T_dummy[n](each stateSelect=StateSelect.prefer, start=fill(T_start,n)) = T_wall if not stat;
 
 equation
   for j in 1:n loop


### PR DESCRIPTION
StateSelect.alwasy cannot always be respected, e.g. when coupling medium models to algebraic models or in case of index reduction, and may cause compilation failures.